### PR TITLE
타이어 만들기 페이지 구현 - 휠 모양 선택 close #17

### DIFF
--- a/src/components/header/index.style.tsx
+++ b/src/components/header/index.style.tsx
@@ -18,6 +18,11 @@ const Container = styled.div<WrapperProps>`
   align-items: center;
   padding-left: 120px;
   font-weight: 600;
+  .link {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+  }
   .title {
     padding: 0 20px;
     font-size: 25px;

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -1,17 +1,33 @@
 import Logo from '@components/logo';
 import Container from './index.style';
+import { useRecoilState } from 'recoil';
+import { selectedPatternIdState } from '@context/pattern';
+import { selectedWheelIdState } from '@context/wheel';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
 
 interface HeaderProps {
   inversion?: boolean;
 }
 
 function Header(props: HeaderProps) {
+  const navigate = useNavigate();
+  const [, setSelectedPattern] = useRecoilState(selectedPatternIdState);
+  const [, setSelectedWheel] = useRecoilState(selectedWheelIdState);
+
+  useEffect(() => {
+    setSelectedPattern(0);
+    setSelectedWheel(0);
+  }, []);
+
   return (
     <Container inversion={props.inversion ? 'true' : 'false'}>
-      <Logo inversion={props.inversion ? 'false' : 'true'} type="small" />
-      <div className="title">Outfit Of Tire</div>
-      <div className="sep" />
-      <div className="title">내 타이어 만들기</div>
+      <div className="link" onClick={() => navigate('/')}>
+        <Logo inversion={props.inversion ? 'false' : 'true'} type="small" />
+        <div className="title">Outfit Of Tire</div>
+        <div className="sep" />
+        <div className="title">내 타이어 만들기</div>
+      </div>
     </Container>
   );
 }

--- a/src/context/wheel.ts
+++ b/src/context/wheel.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const selectedWheelIdState = atom<number>({
+  key: 'selectedWheelIdState',
+  default: 0,
+});

--- a/src/pages/main/item-list/index.tsx
+++ b/src/pages/main/item-list/index.tsx
@@ -59,7 +59,7 @@ const CustomList = forwardRef<HTMLDivElement>((props, ref) => {
         </div>
         <ItemGroup name="액세서리" data={accessories} />
         <div className="footer">
-          <Button text="타이어 만들기" onClick={() => navigate('/production')} />
+          <Button text="타이어 만들기" onClick={() => navigate('/production?step=0')} />
         </div>
       </Container>
     </>

--- a/src/pages/production/button-group/index.tsx
+++ b/src/pages/production/button-group/index.tsx
@@ -1,15 +1,27 @@
 import Button from '@components/button';
 import { Container } from './index.style';
+import { useNavigate } from 'react-router';
 
 interface ButtonGroupProps {
-  step: 0 | 1 | 2 | 3;
+  step: number;
 }
 
 function ButtonGroup(props: ButtonGroupProps) {
+  const navigate = useNavigate();
+
   return (
     <Container>
-      {props.step > 0 ? <Button text="이전" inversion onClick={() => {}} /> : <></>}
-      <Button text={props.step < 3 ? '다음 단계로' : '결과 확인하기'} onClick={() => {}} />
+      {props.step > 0 ? (
+        <Button text="이전" inversion onClick={() => navigate(`/production?step=${props.step - 1}`)} />
+      ) : (
+        <></>
+      )}
+      <Button
+        text={props.step < 3 ? '다음 단계로' : '결과 확인하기'}
+        onClick={() => {
+          if (props.step < 1) navigate(`/production?step=${props.step + 1}`);
+        }}
+      />
     </Container>
   );
 }

--- a/src/pages/production/index.tsx
+++ b/src/pages/production/index.tsx
@@ -9,15 +9,46 @@ import { selectedPatternIdState } from '@context/pattern';
 import Content from '@pages/production/content';
 import { useRecoilState } from 'recoil';
 import ButtonGroup from './button-group';
+import { useSearchParams } from 'react-router-dom';
+import { WheelData } from '@api/wheel.types';
+import { FontData } from '@api/font.types';
+import { ColorData } from '@api/color.types';
+import { AccessoryData } from '@api/accessory.types';
+import { Wheel } from '@api/wheel';
+import { Font } from '@api/font';
+import { Color } from '@api/color';
+import { Accessory } from '@api/accessory';
+import { selectedWheelIdState } from '@context/wheel';
 
 function CustomPattern() {
+  const [searchParams] = useSearchParams();
   const [patterns, setPatterns] = useState<PatternData[]>([]);
-  const [selectedItem] = useRecoilState(selectedPatternIdState);
+  const [wheels, setWheels] = useState<WheelData[]>([]);
+  const [fonts, setFonts] = useState<FontData[]>([]);
+  const [colors, setColors] = useState<ColorData[]>([]);
+  const [accessories, setAccessories] = useState<AccessoryData[]>([]);
+  const [selectedPattern] = useRecoilState(selectedPatternIdState);
+  const [selectedWheel] = useRecoilState(selectedWheelIdState);
+  const step: number = Number(searchParams.get('step'));
+
+  if (step < 0 || step > 3) {
+    return <div>올바르지 않은 접근입니다.</div>;
+  }
 
   useEffect(() => {
     const getData = async () => {
-      const patterns = await Pattern.list();
+      const [patterns, wheels, fonts, colors, accessories] = await Promise.all([
+        Pattern.list(),
+        Wheel.list(),
+        Font.list(),
+        Color.list(),
+        Accessory.list(),
+      ]);
       setPatterns(patterns);
+      setWheels(wheels);
+      setFonts(fonts);
+      setColors(colors);
+      setAccessories(accessories);
     };
     getData();
   }, []);
@@ -26,11 +57,16 @@ function CustomPattern() {
     <>
       <Container>
         <Header />
-        <TabMenu step={0} />
-        <Content data={patterns[selectedItem]} />
+        <TabMenu step={step} />
+        {step === 0 && <Content data={patterns[selectedPattern]} />}
+        {step === 1 && <Content data={wheels[selectedWheel]} />}
         <div className="footer">
-          <OptionSelector type="square" data={patterns} />
-          <ButtonGroup step={0} />
+          {step === 0 && <OptionSelector type="square" data={patterns} />}
+          {step === 1 && <OptionSelector type="square" data={wheels} />}
+          {step === 2 && <OptionSelector type="circle" data={fonts} />}
+          {step === 2 && <OptionSelector type="circle" data={colors} />}
+          {step === 3 && <OptionSelector type="square" data={accessories} />}
+          <ButtonGroup step={step} />
         </div>
       </Container>
     </>

--- a/src/pages/production/option-selector/index.tsx
+++ b/src/pages/production/option-selector/index.tsx
@@ -7,6 +7,8 @@ import { Container } from './index.style';
 import Item from './item';
 import { useRecoilState } from 'recoil';
 import { selectedPatternIdState } from '@context/pattern';
+import { useSearchParams } from 'react-router-dom';
+import { selectedWheelIdState } from '@context/wheel';
 
 interface OptionSelectorProps {
   type: 'square' | 'circle';
@@ -15,12 +17,28 @@ interface OptionSelectorProps {
 }
 
 function OptionSelector(props: OptionSelectorProps) {
-  const [, setSelectedItem] = useRecoilState(selectedPatternIdState);
+  const [searchParams] = useSearchParams();
+  const [, setSelectedPattern] = useRecoilState(selectedPatternIdState);
+  const [, setSelectedWheel] = useRecoilState(selectedWheelIdState);
+  const step: number = Number(searchParams.get('step'));
 
   return (
     <Container className="option_selector" type={props.type}>
       {props.data.map((item, index) => (
-        <Item id={index} key={index} name={item.name} imageSrc={item.imageUrl} onClick={() => setSelectedItem(index)} />
+        <Item
+          id={index}
+          key={index}
+          name={item.name}
+          imageSrc={item.imageUrl}
+          onClick={() => {
+            {
+              step === 0 && setSelectedPattern(index);
+            }
+            {
+              step === 1 && setSelectedWheel(index);
+            }
+          }}
+        />
       ))}
     </Container>
   );

--- a/src/pages/production/option-selector/item/index.tsx
+++ b/src/pages/production/option-selector/item/index.tsx
@@ -1,6 +1,8 @@
 import { useRecoilState } from 'recoil';
 import { Container, ItemImage, ItemName } from './index.style';
 import { selectedPatternIdState } from '@context/pattern';
+import { selectedWheelIdState } from '@context/wheel';
+import { useSearchParams } from 'react-router-dom';
 
 interface ItemProps {
   id: number;
@@ -10,11 +12,19 @@ interface ItemProps {
 }
 
 function Item(props: ItemProps) {
-  const [selectedItem] = useRecoilState(selectedPatternIdState);
+  const [searchParams] = useSearchParams();
+  const [selectedPattern] = useRecoilState(selectedPatternIdState);
+  const [selectedWheel] = useRecoilState(selectedWheelIdState);
+  const step: number = Number(searchParams.get('step'));
 
   return (
     <Container className="item_cntr" onClick={props.onClick}>
-      <ItemImage className={`item_image ${selectedItem === props.id ? 'selected' : ''}`} src={props.imageSrc} />
+      {step === 0 && (
+        <ItemImage className={`item_image ${selectedPattern === props.id ? 'selected' : ''}`} src={props.imageSrc} />
+      )}
+      {step === 1 && (
+        <ItemImage className={`item_image ${selectedWheel === props.id ? 'selected' : ''}`} src={props.imageSrc} />
+      )}
       <ItemName className="item_name">{props.name}</ItemName>
     </Container>
   );

--- a/src/pages/production/tab-menu/index.tsx
+++ b/src/pages/production/tab-menu/index.tsx
@@ -1,7 +1,7 @@
 import { Container, Title } from './index.style';
 
 interface TabMenuProps {
-  step: 0 | 1 | 2 | 3;
+  step: number;
 }
 
 function TabMenu(props: TabMenuProps) {


### PR DESCRIPTION
## Motivation

- #17 

## Problem Solving

- 휠 선택 context 구현
- query-string을 활용한 프로세스별 라우팅 구현
- 같은 컴포넌트 내에서 프로세스에 따라 다르게 렌더링되도록 구현함
- Header 컴포넌트 클릭 시 메인 페이지 이동

## To Reviewer

![Feb-06-2024 21-11-13](https://github.com/endless-horses/oot-web/assets/68031450/dd759a70-2c22-4380-b18f-25e3ce9c25fb)

- 25초 정도 길이의 GIF 입니다.
- 커스텀 페이지에서 프로세스별 이동(이전 선택 내용 유지됨) 및 헤더 클릭 시 메인 페이지 이동을 확인할 수 있습니다.
- 하단이 살짝 잘린 것은 CSS 문제가 아닌, 캡처 프로그램의 문제입니다.